### PR TITLE
Add sample trading strategies

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+"""Entry point for the trading bot simulator."""
+
+from services.data_service import DataService
+from services.simulation import Simulation
+from services.logger import Logger
+
+
+def main():
+    """Run the application."""
+    data_service = DataService()
+    logger = Logger()
+    simulation = Simulation(data_service, logger)
+
+    logger.log("Application started")
+    simulation.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -1,0 +1,26 @@
+"""Service for retrieving price data from Binance public API."""
+
+from __future__ import annotations
+
+import requests
+
+
+class DataService:
+    """Retrieve price information from Binance."""
+
+    API_URL = "https://api.binance.com/api/v3/ticker/price"
+
+    def fetch_price(self, symbol: str = "BTCUSDT") -> float:
+        """Return the latest price for the given symbol.
+
+        If the request fails, ``0.0`` is returned.
+        """
+        try:
+            response = requests.get(self.API_URL, params={"symbol": symbol}, timeout=5)
+            response.raise_for_status()
+            data = response.json()
+            return float(data.get("price", 0.0))
+        except Exception:
+            # In a real application we would log this error
+            return 0.0
+

--- a/services/logger.py
+++ b/services/logger.py
@@ -1,0 +1,16 @@
+"""Simple logging facility used across the application."""
+
+import logging
+
+
+class Logger:
+    """Wrapper around :mod:`logging` for ease of use."""
+
+    def __init__(self) -> None:
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+        self._logger = logging.getLogger("trading_bot")
+
+    def log(self, message: str) -> None:
+        """Log the provided message."""
+        self._logger.info(message)
+

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Basic trading simulation logic."""
+
+from services.data_service import DataService
+from services.logger import Logger
+
+
+class Simulation:
+    """Run a simple price polling simulation."""
+
+    def __init__(self, data_service: DataService, logger: Logger) -> None:
+        self.data_service = data_service
+        self.logger = logger
+
+    def run(self) -> None:
+        """Fetch the current price and log it."""
+        price = self.data_service.fetch_price()
+        self.logger.log(f"Current BTC price: {price}")
+

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,15 @@
+"""Collection of built-in trading strategies."""
+
+from .rsi_strategy import RSIStrategy
+from .macd_strategy import MACDStrategy
+from .bollinger_strategy import BollingerStrategy
+from .ma_cross_strategy import MACrossStrategy
+from .custom_strategy import CustomStrategy
+
+__all__ = [
+    "RSIStrategy",
+    "MACDStrategy",
+    "BollingerStrategy",
+    "MACrossStrategy",
+    "CustomStrategy",
+]

--- a/strategies/bollinger_strategy.py
+++ b/strategies/bollinger_strategy.py
@@ -1,0 +1,37 @@
+"""Bollinger Bands based trading strategy."""
+
+from __future__ import annotations
+
+from collections import deque
+from statistics import mean, stdev
+
+
+class BollingerStrategy:
+    """Trading signals generated using Bollinger Bands."""
+
+    def __init__(self, period: int = 20, dev_factor: float = 2.0) -> None:
+        self.period = period
+        self.dev_factor = dev_factor
+        self.prices: deque[float] = deque(maxlen=period)
+
+    def _bands(self) -> tuple[float, float]:
+        prices = list(self.prices)
+        mid = mean(prices)
+        if len(prices) < 2:
+            return mid, mid
+        deviation = stdev(prices)
+        upper = mid + self.dev_factor * deviation
+        lower = mid - self.dev_factor * deviation
+        return upper, lower
+
+    def on_price(self, price: float) -> str:
+        """Update price history and return trading signal."""
+        self.prices.append(price)
+        if len(self.prices) < self.period:
+            return "hold"
+        upper, lower = self._bands()
+        if price < lower:
+            return "buy"
+        if price > upper:
+            return "sell"
+        return "hold"

--- a/strategies/custom_strategy.py
+++ b/strategies/custom_strategy.py
@@ -1,0 +1,13 @@
+"""Custom trading strategy placeholder."""
+
+from __future__ import annotations
+
+import random
+
+
+class CustomStrategy:
+    """A naive custom strategy choosing random actions."""
+
+    def on_price(self, price: float) -> str:
+        """Return a random trading signal."""
+        return random.choice(["buy", "sell", "hold"])

--- a/strategies/ma_cross_strategy.py
+++ b/strategies/ma_cross_strategy.py
@@ -1,0 +1,38 @@
+"""Moving Average Crossover trading strategy."""
+
+from __future__ import annotations
+
+from collections import deque
+from statistics import mean
+
+
+class MACrossStrategy:
+    """Simple moving average cross strategy."""
+
+    def __init__(self, short: int = 5, long: int = 20) -> None:
+        if short >= long:
+            raise ValueError("short period must be less than long period")
+        self.short = short
+        self.long = long
+        self.short_prices: deque[float] = deque(maxlen=short)
+        self.long_prices: deque[float] = deque(maxlen=long)
+        self.prev_short_ma: float | None = None
+        self.prev_long_ma: float | None = None
+
+    def on_price(self, price: float) -> str:
+        """Update price history and return trading signal."""
+        self.short_prices.append(price)
+        self.long_prices.append(price)
+        if len(self.long_prices) < self.long:
+            return "hold"
+        short_ma = mean(self.short_prices)
+        long_ma = mean(self.long_prices)
+        signal = "hold"
+        if self.prev_short_ma is not None and self.prev_long_ma is not None:
+            if self.prev_short_ma <= self.prev_long_ma and short_ma > long_ma:
+                signal = "buy"
+            elif self.prev_short_ma >= self.prev_long_ma and short_ma < long_ma:
+                signal = "sell"
+        self.prev_short_ma = short_ma
+        self.prev_long_ma = long_ma
+        return signal

--- a/strategies/macd_strategy.py
+++ b/strategies/macd_strategy.py
@@ -1,0 +1,49 @@
+"""MACD-based trading strategy."""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+def _ema(values: list[float], period: int) -> float:
+    """Compute the Exponential Moving Average."""
+    k = 2 / (period + 1)
+    ema = values[0]
+    for price in values[1:]:
+        ema = price * k + ema * (1 - k)
+    return ema
+
+
+class MACDStrategy:
+    """Moving Average Convergence Divergence strategy."""
+
+    def __init__(self, short: int = 12, long: int = 26, signal: int = 9) -> None:
+        self.short = short
+        self.long = long
+        self.signal = signal
+        self.prices: deque[float] = deque(maxlen=long + signal)
+        self._macd_hist: list[float] = []
+
+    def _compute_macd(self) -> tuple[float, float]:
+        prices = list(self.prices)
+        ema_short = _ema(prices[-self.short :], self.short)
+        ema_long = _ema(prices[-self.long :], self.long)
+        macd = ema_short - ema_long
+        self._macd_hist.append(macd)
+        if len(self._macd_hist) < self.signal:
+            signal_line = macd
+        else:
+            signal_line = _ema(self._macd_hist[-self.signal :], self.signal)
+        return macd, signal_line
+
+    def on_price(self, price: float) -> str:
+        """Update price history and return trading signal."""
+        self.prices.append(price)
+        if len(self.prices) < self.long + self.signal:
+            return "hold"
+        macd, signal_line = self._compute_macd()
+        if macd > signal_line:
+            return "buy"
+        if macd < signal_line:
+            return "sell"
+        return "hold"

--- a/strategies/rsi_strategy.py
+++ b/strategies/rsi_strategy.py
@@ -1,0 +1,43 @@
+"""RSI-based trading strategy."""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+class RSIStrategy:
+    """Simple Relative Strength Index strategy."""
+
+    def __init__(self, period: int = 14) -> None:
+        self.period = period
+        self.prices: deque[float] = deque(maxlen=period + 1)
+
+    def _compute_rsi(self) -> float:
+        gains = []
+        losses = []
+        for i in range(1, len(self.prices)):
+            delta = self.prices[i] - self.prices[i - 1]
+            if delta >= 0:
+                gains.append(delta)
+                losses.append(0)
+            else:
+                gains.append(0)
+                losses.append(-delta)
+        avg_gain = sum(gains) / self.period
+        avg_loss = sum(losses) / self.period
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def on_price(self, price: float) -> str:
+        """Update price history and return trading signal."""
+        self.prices.append(price)
+        if len(self.prices) <= self.period:
+            return "hold"
+        rsi = self._compute_rsi()
+        if rsi < 30:
+            return "buy"
+        if rsi > 70:
+            return "sell"
+        return "hold"


### PR DESCRIPTION
## Summary
- implement basic RSI, MACD, Bollinger Bands, MA Cross and custom strategies
- re-export all strategies in `strategies/__init__.py`

## Testing
- `python -m py_compile main.py services/*.py strategies/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68781f149f3c832eaf358ab7d770e844