### PR TITLE
Implement simple strategies and GUI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,37 @@
+"""Entry point for the trading bot simulator."""
+
+from services.data_service import DataService
+from services.simulation import Simulation
+from services.logger import Logger
+from services.gui import TradingApp
+from strategies import (
+    RSIStrategy,
+    MACDStrategy,
+    BollingerStrategy,
+    MACrossStrategy,
+    RandomStrategy,
+)
+
+
+def main() -> None:
+    """Run the application."""
+    data_service = DataService()
+    logger = Logger()
+    strategies = [
+        RSIStrategy(),
+        MACDStrategy(),
+        BollingerStrategy(),
+        MACrossStrategy(),
+        RandomStrategy(),
+    ]
+    simulation = Simulation(data_service, logger, strategies)
+
+    logger.log("Application started")
+    results = simulation.run()
+
+    app = TradingApp(results)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package."""

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -1,0 +1,39 @@
+"""Service for retrieving price data and historical candles."""
+
+from __future__ import annotations
+
+import json
+import random
+import urllib.request
+from typing import List
+
+
+class DataService:
+    """Retrieve price information from Binance or generate fallback data."""
+
+    def fetch_price(self, symbol: str = "BTCUSDT") -> float:
+        """Return the latest price for the given symbol."""
+        url = f"https://api.binance.com/api/v3/ticker/price?symbol={symbol}"
+        try:
+            with urllib.request.urlopen(url) as resp:
+                data = json.loads(resp.read().decode())
+                return float(data["price"])
+        except Exception:
+            # Network might be disabled; return placeholder value
+            return 0.0
+
+    def get_historical_prices(self, symbol: str = "BTCUSDT", limit: int = 100) -> List[float]:
+        """Return a list of closing prices for the given symbol."""
+        url = (
+            "https://api.binance.com/api/v3/klines"
+            f"?symbol={symbol}&interval=1h&limit={limit}"
+        )
+        try:
+            with urllib.request.urlopen(url) as resp:
+                data = json.loads(resp.read().decode())
+            return [float(item[4]) for item in data]
+        except Exception:
+            prices = [10000.0]
+            for _ in range(limit - 1):
+                prices.append(prices[-1] * (1 + random.uniform(-0.02, 0.02)))
+            return prices

--- a/services/gui.py
+++ b/services/gui.py
@@ -1,0 +1,53 @@
+"""Simple Tkinter GUI to display strategy results."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Tuple
+
+import tkinter as tk
+from tkinter import ttk
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+
+
+class TradingApp:
+    """Display strategy price charts and profits."""
+
+    def __init__(self, results: List[Dict]):
+        self.results = results
+        self.root = tk.Tk()
+        self.root.title("Trading Simulator")
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        notebook = ttk.Notebook(self.root)
+        notebook.pack(fill="both", expand=True)
+        for result in self.results:
+            frame = ttk.Frame(notebook)
+            notebook.add(frame, text=result["name"])
+            fig, ax = plt.subplots(figsize=(6, 4))
+            prices = result["prices"]
+            ax.plot(prices, label="Price")
+            buys = [i for i, a in result["trades"] if a == "BUY"]
+            sells = [i for i, a in result["trades"] if a == "SELL"]
+            ax.scatter(buys, [prices[i] for i in buys], color="red", label="Buy")
+            ax.scatter(sells, [prices[i] for i in sells], color="green", label="Sell")
+            ax.legend()
+            canvas = FigureCanvasTkAgg(fig, master=frame)
+            canvas.draw()
+            canvas.get_tk_widget().pack(fill="both", expand=True)
+        btn = ttk.Button(self.root, text="Show Profit Table", command=self._show_profit)
+        btn.pack()
+
+    def _show_profit(self) -> None:
+        win = tk.Toplevel(self.root)
+        win.title("Profit Table")
+        tree = ttk.Treeview(win, columns=("strategy", "profit"), show="headings")
+        tree.heading("strategy", text="Strategy")
+        tree.heading("profit", text="Profit (TL)")
+        tree.pack(fill="both", expand=True)
+        for result in self.results:
+            tree.insert("", tk.END, values=(result["name"], f"{result['profit']:.2f}"))
+
+    def run(self) -> None:
+        self.root.mainloop()

--- a/services/logger.py
+++ b/services/logger.py
@@ -1,0 +1,15 @@
+"""Simple logging facility used across the application."""
+
+import logging
+
+
+class Logger:
+    """Wrapper around :mod:`logging` for ease of use."""
+
+    def __init__(self) -> None:
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+        self._logger = logging.getLogger("trading_bot")
+
+    def log(self, message: str) -> None:
+        """Log the provided message."""
+        self._logger.info(message)

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -1,0 +1,52 @@
+"""Trading simulation logic using supplied strategies."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from services.data_service import DataService
+from services.logger import Logger
+
+
+class Simulation:
+    """Simulate trades for each strategy on historical price data."""
+
+    def __init__(self, data_service: DataService, logger: Logger, strategies: Iterable) -> None:
+        self.data_service = data_service
+        self.logger = logger
+        self.strategies = list(strategies)
+
+    def run(self) -> List[dict]:
+        """Run the simulation and return results per strategy."""
+        prices = self.data_service.get_historical_prices()
+        results = []
+        for strategy in self.strategies:
+            balance = 10000.0
+            position = 0.0
+            trades: List[tuple[int, str]] = []
+            signals = strategy.generate_signals(prices)
+            signals_index = 0
+            for i, price in enumerate(prices):
+                while signals_index < len(signals) and signals[signals_index][0] == i:
+                    action = signals[signals_index][1]
+                    if action == "BUY" and balance > 0:
+                        position = balance / price
+                        balance = 0.0
+                        trades.append((i, "BUY"))
+                    elif action == "SELL" and position > 0:
+                        balance = position * price
+                        position = 0.0
+                        trades.append((i, "SELL"))
+                    signals_index += 1
+            if position > 0:
+                balance = position * prices[-1]
+                trades.append((len(prices) - 1, "SELL"))
+            profit = balance - 10000.0
+            results.append({
+                "name": strategy.name,
+                "prices": prices,
+                "trades": trades,
+                "profit": profit,
+            })
+            self.logger.log(f"{strategy.name} profit: {profit:.2f}")
+        return results

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,15 @@
+"""Collection of trading strategies."""
+
+from .rsi import RSIStrategy
+from .macd import MACDStrategy
+from .bollinger import BollingerStrategy
+from .ma_cross import MACrossStrategy
+from .random_strategy import RandomStrategy
+
+__all__ = [
+    "RSIStrategy",
+    "MACDStrategy",
+    "BollingerStrategy",
+    "MACrossStrategy",
+    "RandomStrategy",
+]

--- a/strategies/bollinger.py
+++ b/strategies/bollinger.py
@@ -1,0 +1,27 @@
+"""Bollinger Bands trading strategy."""
+
+from __future__ import annotations
+
+from typing import List
+import statistics
+
+
+class BollingerStrategy:
+    """Buy below lower band, sell above upper band."""
+
+    name = "Bollinger"
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str]]:
+        signals: List[tuple[int, str]] = []
+        period = 20
+        for i in range(period, len(prices)):
+            window = prices[i - period : i]
+            avg = sum(window) / period
+            std = statistics.stdev(window)
+            upper = avg + 2 * std
+            lower = avg - 2 * std
+            if prices[i] < lower:
+                signals.append((i, "BUY"))
+            elif prices[i] > upper:
+                signals.append((i, "SELL"))
+        return signals

--- a/strategies/ma_cross.py
+++ b/strategies/ma_cross.py
@@ -1,0 +1,26 @@
+"""Moving Average Cross strategy."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class MACrossStrategy:
+    """Buy when short MA crosses above long MA, sell when opposite."""
+
+    name = "MA Cross"
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str]]:
+        short_period = 5
+        long_period = 20
+        signals: List[tuple[int, str]] = []
+        for i in range(long_period, len(prices)):
+            short_avg = sum(prices[i - short_period : i]) / short_period
+            long_avg = sum(prices[i - long_period : i]) / long_period
+            prev_short_avg = sum(prices[i - short_period - 1 : i - 1]) / short_period
+            prev_long_avg = sum(prices[i - long_period - 1 : i - 1]) / long_period
+            if prev_short_avg <= prev_long_avg and short_avg > long_avg:
+                signals.append((i, "BUY"))
+            elif prev_short_avg >= prev_long_avg and short_avg < long_avg:
+                signals.append((i, "SELL"))
+        return signals

--- a/strategies/macd.py
+++ b/strategies/macd.py
@@ -1,0 +1,35 @@
+"""Moving Average Convergence Divergence strategy."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def ema(prices: List[float], period: int) -> List[float]:
+    ema_values: List[float] = []
+    k = 2 / (period + 1)
+    for i, price in enumerate(prices):
+        if i == 0:
+            ema_values.append(price)
+        else:
+            ema_values.append(price * k + ema_values[-1] * (1 - k))
+    return ema_values
+
+
+class MACDStrategy:
+    """Buy when MACD crosses above signal, sell when crosses below."""
+
+    name = "MACD"
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str]]:
+        short = ema(prices, 12)
+        long_ = ema(prices, 26)
+        macd_line = [s - l for s, l in zip(short, long_)]
+        signal_line = ema(macd_line, 9)
+        signals: List[tuple[int, str]] = []
+        for i in range(1, len(prices)):
+            if macd_line[i - 1] < signal_line[i - 1] and macd_line[i] > signal_line[i]:
+                signals.append((i, "BUY"))
+            elif macd_line[i - 1] > signal_line[i - 1] and macd_line[i] < signal_line[i]:
+                signals.append((i, "SELL"))
+        return signals

--- a/strategies/random_strategy.py
+++ b/strategies/random_strategy.py
@@ -1,0 +1,22 @@
+"""Randomized trading strategy."""
+
+from __future__ import annotations
+
+import random
+from typing import List
+
+
+class RandomStrategy:
+    """Randomly issue buy or sell signals."""
+
+    name = "Random"
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str]]:
+        signals: List[tuple[int, str]] = []
+        for i in range(len(prices)):
+            r = random.random()
+            if r < 0.02:
+                signals.append((i, "BUY"))
+            elif r > 0.98:
+                signals.append((i, "SELL"))
+        return signals

--- a/strategies/rsi.py
+++ b/strategies/rsi.py
@@ -1,0 +1,31 @@
+"""Relative Strength Index trading strategy."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class RSIStrategy:
+    """Buy when RSI < 30, sell when RSI > 70."""
+
+    name = "RSI"
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str]]:
+        signals: List[tuple[int, str]] = []
+        gains: List[float] = []
+        losses: List[float] = []
+        for i in range(1, len(prices)):
+            change = prices[i] - prices[i - 1]
+            gains.append(max(change, 0))
+            losses.append(max(-change, 0))
+            if i < 14:
+                continue
+            avg_gain = sum(gains[-14:]) / 14
+            avg_loss = sum(losses[-14:]) / 14
+            rs = avg_gain / avg_loss if avg_loss != 0 else 0
+            rsi = 100 - 100 / (1 + rs)
+            if rsi < 30:
+                signals.append((i, "BUY"))
+            elif rsi > 70:
+                signals.append((i, "SELL"))
+        return signals


### PR DESCRIPTION
## Summary
- create actual strategy modules and expose them
- simulate trading over sample price history with profit logging
- add Tkinter-based GUI showing charts for each strategy and a profit table
- fetch historical prices from Binance when possible with fallback

## Testing
- `python -m py_compile main.py services/*.py strategies/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68781f149f3c832eaf358ab7d770e844