### PR TITLE
Add trade amount display and 24h simulation

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -14,6 +14,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
   - Buy points (red), sell points (green)
 - Collective profit/loss table:
   - Total gains/losses of each strategy
+  - Remaining BTC and its value per strategy
 - Detailed trade log listing each trade with updated balance
 - Easy switching between graphs and table
 - Modern and user-friendly interface

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,6 +8,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Apply the five most commonly used and trusted trading strategies
 - Simulate long/short trades with an independent 10,000 TL balance for each strategy
 - Real-time buy/sell simulation adjusts position size according to signal strength
+- Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
 - Separate graph for each strategy:
   - Price curve
   - Buy points (red), sell points (green)

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,6 +14,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
   - Buy points (red), sell points (green)
 - Collective profit/loss table:
   - Total gains/losses of each strategy
+- Detailed trade log listing each trade with updated balance
 - Easy switching between graphs and table
 - Modern and user-friendly interface
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -15,6 +15,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Collective profit/loss table:
   - Total gains/losses of each strategy
   - Remaining BTC and its value per strategy
+  - Final balance for each strategy
 - Detailed trade log listing each trade with updated balance
 - Easy switching between graphs and table
 - Modern and user-friendly interface

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,12 +1,12 @@
 # Bitcoin Trading Strategies Simulator
 
 ## Project Purpose
-This application aims to regularly fetch the Bitcoin price using the Binance API and simulate five popular and safe trading strategies simultaneously in a virtual environment for comparison. Each strategy starts with a virtual balance of 10,000 TL, and the results are presented with detailed graphs and profit/loss tables.
+This application aims to regularly fetch the Bitcoin price using the Binance API and simulate five popular and safe trading strategies simultaneously in a virtual environment for comparison. All strategies share a single virtual balance of 10,000 TL, and the results are presented with detailed graphs and profit/loss tables.
 
 ## Features
 - Fetch the Bitcoin price every five minutes using your Binance API key
 - Apply the five most commonly used and trusted trading strategies
-- Simulate long/short trades with a virtual balance of 10,000 TL for each strategy
+- Simulate long/short trades with a shared virtual balance of 10,000 TL
 - Real-time buy/sell simulation adjusts position size according to signal strength
 - Separate graph for each strategy:
   - Price curve

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,12 +1,12 @@
 # Bitcoin Trading Strategies Simulator
 
 ## Project Purpose
-This application aims to regularly fetch the Bitcoin price using the Binance API and simulate five popular and safe trading strategies simultaneously in a virtual environment for comparison. All strategies share a single virtual balance of 10,000 TL, and the results are presented with detailed graphs and profit/loss tables.
+This application aims to regularly fetch the Bitcoin price using the Binance API and simulate five popular and safe trading strategies simultaneously in a virtual environment for comparison. Each strategy trades with its own virtual balance of 10,000 TL, and the results are presented with detailed graphs and profit/loss tables.
 
 ## Features
 - Fetch the Bitcoin price every five minutes using your Binance API key
 - Apply the five most commonly used and trusted trading strategies
-- Simulate long/short trades with a shared virtual balance of 10,000 TL
+- Simulate long/short trades with an independent 10,000 TL balance for each strategy
 - Real-time buy/sell simulation adjusts position size according to signal strength
 - Separate graph for each strategy:
   - Price curve

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
 Bitcoin Trading Strategies Simulator
 Proje Amacı
-Bu uygulama, Binance API ile Bitcoin fiyatını düzenli olarak çekerek, popüler ve güvenli 5 farklı borsa stratejisini eş zamanlı olarak sanal ortamda test etmeyi ve karşılaştırmalı analiz yapmayı amaçlar. Her strateji için 10.000 TL’lik başlangıç bakiyesi ile işlem simülasyonu gerçekleştirilir ve sonuçlar detaylı grafikler ve kar/zarar tabloları ile sunulur.
+Bu uygulama, Binance API ile Bitcoin fiyatını düzenli olarak çekerek, popüler ve güvenli 5 farklı borsa stratejisini eş zamanlı olarak sanal ortamda test etmeyi ve karşılaştırmalı analiz yapmayı amaçlar. Tüm stratejiler 10.000 TL'lik ortak bir bakiye ile işlem yapar ve sonuçlar detaylı grafikler ile kar/zarar tabloları halinde sunulur.
 
 Özellikler
 Binance API anahtarı ile 5 dakikada bir Bitcoin fiyatı çekme
 
 Kısa sürede en çok kullanılan ve güvenli 5 farklı trade stratejisinin uygulanması
 
-Her stratejiye 10.000 TL sanal bakiye ile long/short işlemlerini simüle etme
+10.000 TL ortak sanal bakiye ile long/short işlemlerini simüle etme
 Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyüklüğü ayarlanır
 
 Her strateji için ayrı grafik:

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Kısa sürede en çok kullanılan ve güvenli 5 farklı trade stratejisinin uygu
 
 Her strateji için 10.000 TL'lik bağımsız sanal bakiye ile long/short işlemlerini simüle etme
 Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyüklüğü ayarlanır
+- Beklenen kâr %2'yi aşıyorsa sinyal gücü düşük olsa bile tüm pozisyon satılabilir
 
 Her strateji için ayrı grafik:
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Toplu kar/zarar tablosu:
 
 Her stratejinin toplamda ne kadar kazandırdığı/kaybettirdiği
 Her stratejinin elinde kalan BTC miktarı ve karşılık gelen değeri
+Her stratejinin simülasyon sonundaki toplam bakiyesi
 Güncellenmiş bakiye ile her işlemi listeleyen ayrıntılı işlem günlüğü
 
 Grafikler ve tablo arası kolay geçiş

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Alım noktaları (kırmızı), satım noktaları (yeşil)
 Toplu kar/zarar tablosu:
 
 Her stratejinin toplamda ne kadar kazandırdığı/kaybettirdiği
+Her stratejinin elinde kalan BTC miktarı ve karşılık gelen değeri
 Güncellenmiş bakiye ile her işlemi listeleyen ayrıntılı işlem günlüğü
 
 Grafikler ve tablo arası kolay geçiş

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Alım noktaları (kırmızı), satım noktaları (yeşil)
 Toplu kar/zarar tablosu:
 
 Her stratejinin toplamda ne kadar kazandırdığı/kaybettirdiği
+Güncellenmiş bakiye ile her işlemi listeleyen ayrıntılı işlem günlüğü
 
 Grafikler ve tablo arası kolay geçiş
 

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
 Bitcoin Trading Strategies Simulator
 Proje Amacı
-Bu uygulama, Binance API ile Bitcoin fiyatını düzenli olarak çekerek, popüler ve güvenli 5 farklı borsa stratejisini eş zamanlı olarak sanal ortamda test etmeyi ve karşılaştırmalı analiz yapmayı amaçlar. Tüm stratejiler 10.000 TL'lik ortak bir bakiye ile işlem yapar ve sonuçlar detaylı grafikler ile kar/zarar tabloları halinde sunulur.
+Bu uygulama, Binance API ile Bitcoin fiyatını düzenli olarak çekerek, popüler ve güvenli 5 farklı borsa stratejisini eş zamanlı olarak sanal ortamda test etmeyi ve karşılaştırmalı analiz yapmayı amaçlar. Her strateji 10.000 TL'lik kendi bakiyesi ile işlem yapar ve sonuçlar detaylı grafikler ile kar/zarar tabloları halinde sunulur.
 
 Özellikler
 Binance API anahtarı ile 5 dakikada bir Bitcoin fiyatı çekme
 
 Kısa sürede en çok kullanılan ve güvenli 5 farklı trade stratejisinin uygulanması
 
-10.000 TL ortak sanal bakiye ile long/short işlemlerini simüle etme
+Her strateji için 10.000 TL'lik bağımsız sanal bakiye ile long/short işlemlerini simüle etme
 Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyüklüğü ayarlanır
 
 Her strateji için ayrı grafik:

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -22,11 +22,13 @@ class DataService:
             # Network might be disabled; return placeholder value
             return 0.0
 
-    def get_historical_prices(self, symbol: str = "BTCUSDT", limit: int = 100) -> List[float]:
+    def get_historical_prices(
+        self, symbol: str = "BTCUSDT", limit: int = 100, interval: str = "1h"
+    ) -> List[float]:
         """Return a list of closing prices for the given symbol."""
         url = (
             "https://api.binance.com/api/v3/klines"
-            f"?symbol={symbol}&interval=1h&limit={limit}"
+            f"?symbol={symbol}&interval={interval}&limit={limit}"
         )
         try:
             with urllib.request.urlopen(url) as resp:

--- a/services/gui.py
+++ b/services/gui.py
@@ -28,8 +28,16 @@ class TradingApp:
             fig, ax = plt.subplots(figsize=(6, 4))
             prices = result["prices"]
             ax.plot(prices, label="Price")
-            buys = [(i, amt, price) for i, a, amt, price in result["trades"] if a == "BUY"]
-            sells = [(i, amt, price) for i, a, amt, price in result["trades"] if a == "SELL"]
+            buys = [
+                (i, amt, price)
+                for i, a, amt, price, _ in result["trades"]
+                if a == "BUY"
+            ]
+            sells = [
+                (i, amt, price)
+                for i, a, amt, price, _ in result["trades"]
+                if a == "SELL"
+            ]
             ax.scatter([b[0] for b in buys], [b[2] for b in buys], color="red", label="Buy")
             ax.scatter([s[0] for s in sells], [s[2] for s in sells], color="green", label="Sell")
             for idx, amt, trade_price in buys:
@@ -72,13 +80,16 @@ class TradingApp:
     def _show_trades(self) -> None:
         win = tk.Toplevel(self.root)
         win.title("Trade Log")
-        cols = ("strategy", "candle", "action", "amount", "price")
+        cols = ("strategy", "candle", "action", "amount", "price", "balance")
         tree = ttk.Treeview(win, columns=cols, show="headings")
-        for col, text in zip(cols, ["Strategy", "Candle", "Action", "Amount (BTC)", "Price"]):
+        for col, text in zip(
+            cols,
+            ["Strategy", "Candle", "Action", "Amount (BTC)", "Price", "Balance (TL)"],
+        ):
             tree.heading(col, text=text)
         tree.pack(fill="both", expand=True)
         for result in self.results:
-            for idx, action, amount, price in result["trades"]:
+            for idx, action, amount, price, balance in result["trades"]:
                 tree.insert(
                     "",
                     tk.END,
@@ -88,6 +99,7 @@ class TradingApp:
                         action,
                         f"{amount:.4f}",
                         f"{price:.2f}",
+                        f"{balance:.2f}",
                     ),
                 )
 

--- a/services/gui.py
+++ b/services/gui.py
@@ -28,20 +28,22 @@ class TradingApp:
             fig, ax = plt.subplots(figsize=(6, 4))
             prices = result["prices"]
             ax.plot(prices, label="Price")
-            buys = [(i, amt) for i, a, amt in result["trades"] if a == "BUY"]
-            sells = [(i, amt) for i, a, amt in result["trades"] if a == "SELL"]
-            ax.scatter([b[0] for b in buys], [prices[b[0]] for b in buys], color="red", label="Buy")
-            ax.scatter([s[0] for s in sells], [prices[s[0]] for s in sells], color="green", label="Sell")
-            for idx, amt in buys:
-                ax.annotate(f"{amt:.4f}", (idx, prices[idx]), textcoords="offset points", xytext=(0, 5), ha="center", color="red")
-            for idx, amt in sells:
-                ax.annotate(f"{amt:.4f}", (idx, prices[idx]), textcoords="offset points", xytext=(0, 5), ha="center", color="green")
+            buys = [(i, amt, price) for i, a, amt, price in result["trades"] if a == "BUY"]
+            sells = [(i, amt, price) for i, a, amt, price in result["trades"] if a == "SELL"]
+            ax.scatter([b[0] for b in buys], [b[2] for b in buys], color="red", label="Buy")
+            ax.scatter([s[0] for s in sells], [s[2] for s in sells], color="green", label="Sell")
+            for idx, amt, trade_price in buys:
+                ax.annotate(f"{amt:.4f}", (idx, trade_price), textcoords="offset points", xytext=(0, 5), ha="center", color="red")
+            for idx, amt, trade_price in sells:
+                ax.annotate(f"{amt:.4f}", (idx, trade_price), textcoords="offset points", xytext=(0, 5), ha="center", color="green")
             ax.legend()
             canvas = FigureCanvasTkAgg(fig, master=frame)
             canvas.draw()
             canvas.get_tk_widget().pack(fill="both", expand=True)
         btn = ttk.Button(self.root, text="Show Profit Table", command=self._show_profit)
         btn.pack()
+        btn2 = ttk.Button(self.root, text="Show Trades", command=self._show_trades)
+        btn2.pack()
 
     def _show_profit(self) -> None:
         win = tk.Toplevel(self.root)
@@ -66,6 +68,28 @@ class TradingApp:
                     f"{result['sold']:.4f}",
                 ),
             )
+
+    def _show_trades(self) -> None:
+        win = tk.Toplevel(self.root)
+        win.title("Trade Log")
+        cols = ("strategy", "candle", "action", "amount", "price")
+        tree = ttk.Treeview(win, columns=cols, show="headings")
+        for col, text in zip(cols, ["Strategy", "Candle", "Action", "Amount (BTC)", "Price"]):
+            tree.heading(col, text=text)
+        tree.pack(fill="both", expand=True)
+        for result in self.results:
+            for idx, action, amount, price in result["trades"]:
+                tree.insert(
+                    "",
+                    tk.END,
+                    values=(
+                        result["name"],
+                        idx,
+                        action,
+                        f"{amount:.4f}",
+                        f"{price:.2f}",
+                    ),
+                )
 
     def run(self) -> None:
         self.root.mainloop()

--- a/services/gui.py
+++ b/services/gui.py
@@ -28,10 +28,14 @@ class TradingApp:
             fig, ax = plt.subplots(figsize=(6, 4))
             prices = result["prices"]
             ax.plot(prices, label="Price")
-            buys = [i for i, a in result["trades"] if a == "BUY"]
-            sells = [i for i, a in result["trades"] if a == "SELL"]
-            ax.scatter(buys, [prices[i] for i in buys], color="red", label="Buy")
-            ax.scatter(sells, [prices[i] for i in sells], color="green", label="Sell")
+            buys = [(i, amt) for i, a, amt in result["trades"] if a == "BUY"]
+            sells = [(i, amt) for i, a, amt in result["trades"] if a == "SELL"]
+            ax.scatter([b[0] for b in buys], [prices[b[0]] for b in buys], color="red", label="Buy")
+            ax.scatter([s[0] for s in sells], [prices[s[0]] for s in sells], color="green", label="Sell")
+            for idx, amt in buys:
+                ax.annotate(f"{amt:.4f}", (idx, prices[idx]), textcoords="offset points", xytext=(0, 5), ha="center", color="red")
+            for idx, amt in sells:
+                ax.annotate(f"{amt:.4f}", (idx, prices[idx]), textcoords="offset points", xytext=(0, 5), ha="center", color="green")
             ax.legend()
             canvas = FigureCanvasTkAgg(fig, master=frame)
             canvas.draw()
@@ -42,12 +46,24 @@ class TradingApp:
     def _show_profit(self) -> None:
         win = tk.Toplevel(self.root)
         win.title("Profit Table")
-        tree = ttk.Treeview(win, columns=("strategy", "profit"), show="headings")
+        cols = ("strategy", "profit", "bought", "sold")
+        tree = ttk.Treeview(win, columns=cols, show="headings")
         tree.heading("strategy", text="Strategy")
         tree.heading("profit", text="Profit (TL)")
+        tree.heading("bought", text="Bought (BTC)")
+        tree.heading("sold", text="Sold (BTC)")
         tree.pack(fill="both", expand=True)
         for result in self.results:
-            tree.insert("", tk.END, values=(result["name"], f"{result['profit']:.2f}"))
+            tree.insert(
+                "",
+                tk.END,
+                values=(
+                    result["name"],
+                    f"{result['profit']:.2f}",
+                    f"{result['bought']:.4f}",
+                    f"{result['sold']:.4f}",
+                ),
+            )
 
     def run(self) -> None:
         self.root.mainloop()

--- a/services/gui.py
+++ b/services/gui.py
@@ -46,10 +46,11 @@ class TradingApp:
     def _show_profit(self) -> None:
         win = tk.Toplevel(self.root)
         win.title("Profit Table")
-        cols = ("strategy", "profit", "bought", "sold")
+        cols = ("strategy", "profit", "profit_pct", "bought", "sold")
         tree = ttk.Treeview(win, columns=cols, show="headings")
         tree.heading("strategy", text="Strategy")
         tree.heading("profit", text="Profit (TL)")
+        tree.heading("profit_pct", text="Profit (%)")
         tree.heading("bought", text="Bought (BTC)")
         tree.heading("sold", text="Sold (BTC)")
         tree.pack(fill="both", expand=True)
@@ -60,6 +61,7 @@ class TradingApp:
                 values=(
                     result["name"],
                     f"{result['profit']:.2f}",
+                    f"{result['profit_pct']:.2f}",
                     f"{result['bought']:.4f}",
                     f"{result['sold']:.4f}",
                 ),

--- a/services/gui.py
+++ b/services/gui.py
@@ -60,6 +60,7 @@ class TradingApp:
             "strategy",
             "profit",
             "profit_pct",
+            "balance",
             "bought",
             "sold",
             "remaining",
@@ -69,6 +70,7 @@ class TradingApp:
         tree.heading("strategy", text="Strategy")
         tree.heading("profit", text="Profit (TL)")
         tree.heading("profit_pct", text="Profit (%)")
+        tree.heading("balance", text="Balance (TL)")
         tree.heading("bought", text="Bought (BTC)")
         tree.heading("sold", text="Sold (BTC)")
         tree.heading("remaining", text="Remaining (BTC)")
@@ -82,6 +84,7 @@ class TradingApp:
                     result["name"],
                     f"{result['profit']:.2f}",
                     f"{result['profit_pct']:.2f}",
+                    f"{result['final_balance']:.2f}",
                     f"{result['bought']:.4f}",
                     f"{result['sold']:.4f}",
                     f"{result['remaining_btc']:.4f}",

--- a/services/gui.py
+++ b/services/gui.py
@@ -56,13 +56,23 @@ class TradingApp:
     def _show_profit(self) -> None:
         win = tk.Toplevel(self.root)
         win.title("Profit Table")
-        cols = ("strategy", "profit", "profit_pct", "bought", "sold")
+        cols = (
+            "strategy",
+            "profit",
+            "profit_pct",
+            "bought",
+            "sold",
+            "remaining",
+            "value",
+        )
         tree = ttk.Treeview(win, columns=cols, show="headings")
         tree.heading("strategy", text="Strategy")
         tree.heading("profit", text="Profit (TL)")
         tree.heading("profit_pct", text="Profit (%)")
         tree.heading("bought", text="Bought (BTC)")
         tree.heading("sold", text="Sold (BTC)")
+        tree.heading("remaining", text="Remaining (BTC)")
+        tree.heading("value", text="Value (TL)")
         tree.pack(fill="both", expand=True)
         for result in self.results:
             tree.insert(
@@ -74,6 +84,8 @@ class TradingApp:
                     f"{result['profit_pct']:.2f}",
                     f"{result['bought']:.4f}",
                     f"{result['sold']:.4f}",
+                    f"{result['remaining_btc']:.4f}",
+                    f"{result['holding_value']:.2f}",
                 ),
             )
 

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -72,6 +72,7 @@ class Simulation:
                     "prices": prices,
                     "trades": trades,
                     "profit": profit,
+                    "final_balance": final_value,
                     "profit_pct": profit_pct,
                     "bought": bought_total,
                     "sold": sold_total,

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -61,7 +61,8 @@ class Simulation:
                         sold_total += amount
                     idx += 1
 
-            final_value = balance + position * prices[-1]
+            holding_value = position * prices[-1]
+            final_value = balance + holding_value
             profit = final_value - 10000.0
             profit_pct = (profit / 10000.0) * 100
 
@@ -74,6 +75,8 @@ class Simulation:
                     "profit_pct": profit_pct,
                     "bought": bought_total,
                     "sold": sold_total,
+                    "remaining_btc": position,
+                    "holding_value": holding_value,
                 }
             )
             self.logger.log(f"{strategy.name} profit: {profit:.2f}")

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -18,8 +18,8 @@ class Simulation:
 
     def run(self) -> List[dict]:
         """Run the simulation and return results per strategy."""
-        # Only use the last 24 hours of historical prices (1h interval)
-        prices = self.data_service.get_historical_prices(limit=24)
+        # Use daily candles for the last month of data
+        prices = self.data_service.get_historical_prices(limit=30, interval="1d")
         results = []
         for strategy in self.strategies:
             balance = 10000.0
@@ -49,11 +49,13 @@ class Simulation:
                     signals_index += 1
             final_balance = balance + position * prices[-1]
             profit = final_balance - 10000.0
+            profit_pct = (profit / 10000.0) * 100
             results.append({
                 "name": strategy.name,
                 "prices": prices,
                 "trades": trades,
                 "profit": profit,
+                "profit_pct": profit_pct,
                 "bought": total_bought,
                 "sold": total_sold,
             })

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -18,8 +18,8 @@ class Simulation:
 
     def run(self) -> List[dict]:
         """Run the simulation and return results per strategy."""
-        # Use daily candles for the last month of data
-        prices = self.data_service.get_historical_prices(limit=30, interval="1d")
+        # Fetch 24 hours of data using hourly candles
+        prices = self.data_service.get_historical_prices(limit=24, interval="1h")
         results = []
         for strategy in self.strategies:
             balance = 10000.0

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -27,6 +27,7 @@ class Simulation:
             idx = 0
             balance = 10000.0
             position = 0.0
+            position_cost = 0.0
             trades: List[tuple[int, str, float, float]] = []
             bought_total = 0.0
             sold_total = 0.0
@@ -40,12 +41,22 @@ class Simulation:
                         amount = cost / price
                         position += amount
                         balance -= cost
+                        position_cost += cost
                         trades.append((i, "BUY", amount, price))
                         bought_total += amount
                     elif action == "SELL" and position > 0:
-                        amount = position * strength
+                        # Consider selling all if profit would exceed 2% even with low strength
+                        potential_profit = position * price - position_cost
+                        if strength < 0.5 and position_cost > 0 and potential_profit / position_cost >= 0.02:
+                            amount = position
+                        else:
+                            amount = position * strength
+                        if amount > position:
+                            amount = position
+                        sell_cost = (position_cost / position) * amount
                         balance += amount * price
                         position -= amount
+                        position_cost -= sell_cost
                         trades.append((i, "SELL", amount, price))
                         sold_total += amount
                     idx += 1

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -18,8 +18,8 @@ class Simulation:
 
     def run(self) -> List[dict]:
         """Run the simulation and return results per strategy."""
-        # Fetch 24 hours of data using hourly candles
-        prices = self.data_service.get_historical_prices(limit=24, interval="1h")
+        # Fetch 24 hours of data using 5 minute candles (288 total)
+        prices = self.data_service.get_historical_prices(limit=288, interval="5m")
         results = []
         for strategy in self.strategies:
             balance = 10000.0

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -20,29 +20,19 @@ class Simulation:
         """Run the simulation and return results per strategy."""
         # Fetch 24 hours of data using 5 minute candles (288 total)
         prices = self.data_service.get_historical_prices(limit=288, interval="5m")
-        # Shared account for all strategies
-        balance = 10000.0
-        position = 0.0
 
-        # Precompute signals per strategy
-        signals_map: dict = {}
-        index_map: dict = {}
-        trades_map: dict = {}
-        bought_map: dict = {}
-        sold_map: dict = {}
-        profit_map: dict = {}
+        results = []
         for strategy in self.strategies:
-            signals_map[strategy] = strategy.generate_signals(prices)
-            index_map[strategy] = 0
-            trades_map[strategy] = []
-            bought_map[strategy] = 0.0
-            sold_map[strategy] = 0.0
-            profit_map[strategy] = 0.0
+            signals = strategy.generate_signals(prices)
+            idx = 0
+            balance = 10000.0
+            position = 0.0
+            trades: List[tuple[int, str, float, float]] = []
+            bought_total = 0.0
+            sold_total = 0.0
+            profit = 0.0
 
-        for i, price in enumerate(prices):
-            for strategy in self.strategies:
-                idx = index_map[strategy]
-                signals = signals_map[strategy]
+            for i, price in enumerate(prices):
                 while idx < len(signals) and signals[idx][0] == i:
                     _, action, strength = signals[idx]
                     strength = max(0.0, min(1.0, strength))
@@ -52,37 +42,32 @@ class Simulation:
                         amount = cost / price
                         position += amount
                         balance -= cost
-                        trades_map[strategy].append((i, "BUY", amount))
-                        bought_map[strategy] += amount
+                        trades.append((i, "BUY", amount, price))
+                        bought_total += amount
                     elif action == "SELL" and position > 0:
                         amount = position * strength
                         balance += amount * price
                         position -= amount
-                        trades_map[strategy].append((i, "SELL", amount))
-                        sold_map[strategy] += amount
+                        trades.append((i, "SELL", amount, price))
+                        sold_total += amount
                     new_value = balance + position * price
-                    profit_map[strategy] += new_value - prev_value
+                    profit += new_value - prev_value
                     idx += 1
-                index_map[strategy] = idx
 
-        final_value = balance + position * prices[-1]
-        overall_profit = final_value - 10000.0
-
-        results = []
-        for strategy in self.strategies:
-            profit = profit_map[strategy]
+            final_value = balance + position * prices[-1]
             profit_pct = (profit / 10000.0) * 100
+
             results.append(
                 {
                     "name": strategy.name,
                     "prices": prices,
-                    "trades": trades_map[strategy],
+                    "trades": trades,
                     "profit": profit,
                     "profit_pct": profit_pct,
-                    "bought": bought_map[strategy],
-                    "sold": sold_map[strategy],
+                    "bought": bought_total,
+                    "sold": sold_total,
                 }
             )
             self.logger.log(f"{strategy.name} profit: {profit:.2f}")
-        self.logger.log(f"Overall profit: {overall_profit:.2f}")
+
         return results

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -28,7 +28,7 @@ class Simulation:
             balance = 10000.0
             position = 0.0
             position_cost = 0.0
-            trades: List[tuple[int, str, float, float]] = []
+            trades: List[tuple[int, str, float, float, float]] = []
             bought_total = 0.0
             sold_total = 0.0
 
@@ -42,7 +42,7 @@ class Simulation:
                         position += amount
                         balance -= cost
                         position_cost += cost
-                        trades.append((i, "BUY", amount, price))
+                        trades.append((i, "BUY", amount, price, balance))
                         bought_total += amount
                     elif action == "SELL" and position > 0:
                         # Consider selling all if profit would exceed 2% even with low strength
@@ -57,7 +57,7 @@ class Simulation:
                         balance += amount * price
                         position -= amount
                         position_cost -= sell_cost
-                        trades.append((i, "SELL", amount, price))
+                        trades.append((i, "SELL", amount, price, balance))
                         sold_total += amount
                     idx += 1
 

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -20,44 +20,69 @@ class Simulation:
         """Run the simulation and return results per strategy."""
         # Fetch 24 hours of data using 5 minute candles (288 total)
         prices = self.data_service.get_historical_prices(limit=288, interval="5m")
-        results = []
+        # Shared account for all strategies
+        balance = 10000.0
+        position = 0.0
+
+        # Precompute signals per strategy
+        signals_map: dict = {}
+        index_map: dict = {}
+        trades_map: dict = {}
+        bought_map: dict = {}
+        sold_map: dict = {}
+        profit_map: dict = {}
         for strategy in self.strategies:
-            balance = 10000.0
-            position = 0.0
-            trades: List[tuple[int, str, float]] = []
-            total_bought = 0.0
-            total_sold = 0.0
-            signals = strategy.generate_signals(prices)
-            signals_index = 0
-            for i, price in enumerate(prices):
-                while signals_index < len(signals) and signals[signals_index][0] == i:
-                    _, action, strength = signals[signals_index]
+            signals_map[strategy] = strategy.generate_signals(prices)
+            index_map[strategy] = 0
+            trades_map[strategy] = []
+            bought_map[strategy] = 0.0
+            sold_map[strategy] = 0.0
+            profit_map[strategy] = 0.0
+
+        for i, price in enumerate(prices):
+            for strategy in self.strategies:
+                idx = index_map[strategy]
+                signals = signals_map[strategy]
+                while idx < len(signals) and signals[idx][0] == i:
+                    _, action, strength = signals[idx]
                     strength = max(0.0, min(1.0, strength))
+                    prev_value = balance + position * price
                     if action == "BUY" and balance > 0:
                         cost = balance * strength
                         amount = cost / price
                         position += amount
                         balance -= cost
-                        trades.append((i, "BUY", amount))
-                        total_bought += amount
+                        trades_map[strategy].append((i, "BUY", amount))
+                        bought_map[strategy] += amount
                     elif action == "SELL" and position > 0:
                         amount = position * strength
                         balance += amount * price
                         position -= amount
-                        trades.append((i, "SELL", amount))
-                        total_sold += amount
-                    signals_index += 1
-            final_balance = balance + position * prices[-1]
-            profit = final_balance - 10000.0
+                        trades_map[strategy].append((i, "SELL", amount))
+                        sold_map[strategy] += amount
+                    new_value = balance + position * price
+                    profit_map[strategy] += new_value - prev_value
+                    idx += 1
+                index_map[strategy] = idx
+
+        final_value = balance + position * prices[-1]
+        overall_profit = final_value - 10000.0
+
+        results = []
+        for strategy in self.strategies:
+            profit = profit_map[strategy]
             profit_pct = (profit / 10000.0) * 100
-            results.append({
-                "name": strategy.name,
-                "prices": prices,
-                "trades": trades,
-                "profit": profit,
-                "profit_pct": profit_pct,
-                "bought": total_bought,
-                "sold": total_sold,
-            })
+            results.append(
+                {
+                    "name": strategy.name,
+                    "prices": prices,
+                    "trades": trades_map[strategy],
+                    "profit": profit,
+                    "profit_pct": profit_pct,
+                    "bought": bought_map[strategy],
+                    "sold": sold_map[strategy],
+                }
+            )
             self.logger.log(f"{strategy.name} profit: {profit:.2f}")
+        self.logger.log(f"Overall profit: {overall_profit:.2f}")
         return results

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -30,13 +30,11 @@ class Simulation:
             trades: List[tuple[int, str, float, float]] = []
             bought_total = 0.0
             sold_total = 0.0
-            profit = 0.0
 
             for i, price in enumerate(prices):
                 while idx < len(signals) and signals[idx][0] == i:
                     _, action, strength = signals[idx]
                     strength = max(0.0, min(1.0, strength))
-                    prev_value = balance + position * price
                     if action == "BUY" and balance > 0:
                         cost = balance * strength
                         amount = cost / price
@@ -50,11 +48,10 @@ class Simulation:
                         position -= amount
                         trades.append((i, "SELL", amount, price))
                         sold_total += amount
-                    new_value = balance + position * price
-                    profit += new_value - prev_value
                     idx += 1
 
             final_value = balance + position * prices[-1]
+            profit = final_value - 10000.0
             profit_pct = (profit / 10000.0) * 100
 
             results.append(


### PR DESCRIPTION
## Summary
- simulate last 24 hours instead of 100 hours
- track quantity bought and sold in simulation
- display trade amounts on charts
- show total bought and sold in profit table

## Testing
- `python -m py_compile main.py services/*.py strategies/*.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6878405b3bc8832eb89667c5b383b0b7