### PR TITLE
Add hybrid trading strategy

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from strategies import (
     BollingerStrategy,
     MACrossStrategy,
     RandomStrategy,
+    CustomStrategy,
 )
 
 
@@ -23,6 +24,7 @@ def main() -> None:
         BollingerStrategy(),
         MACrossStrategy(),
         RandomStrategy(),
+        CustomStrategy(),
     ]
     simulation = Simulation(data_service, logger, strategies)
 

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -5,6 +5,7 @@ from .macd import MACDStrategy
 from .bollinger import BollingerStrategy
 from .ma_cross import MACrossStrategy
 from .random_strategy import RandomStrategy
+from .custom_strategy import CustomStrategy
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "BollingerStrategy",
     "MACrossStrategy",
     "RandomStrategy",
+    "CustomStrategy",
 ]

--- a/strategies/custom_strategy.py
+++ b/strategies/custom_strategy.py
@@ -1,13 +1,58 @@
-"""Custom trading strategy placeholder."""
+"""Hybrid trading strategy combining multiple indicators."""
 
 from __future__ import annotations
 
-import random
+from typing import List
+
+from .bollinger import BollingerStrategy
+from .macd import MACDStrategy
+from .ma_cross import MACrossStrategy
+from .rsi import RSIStrategy
 
 
 class CustomStrategy:
-    """A naive custom strategy choosing random actions."""
+    """Generate signals based on a consensus of other strategies."""
 
-    def on_price(self, price: float) -> str:
-        """Return a random trading signal."""
-        return random.choice(["buy", "sell", "hold"])
+    name = "Hybrid"
+
+    def __init__(
+        self,
+        profit_threshold: float | None = None,
+        trailing_stop_pct: float | None = None,
+    ) -> None:
+        self.profit_threshold = profit_threshold
+        self.trailing_stop_pct = trailing_stop_pct
+        self._strategies = [
+            RSIStrategy(profit_threshold, trailing_stop_pct),
+            MACDStrategy(profit_threshold, trailing_stop_pct),
+            BollingerStrategy(profit_threshold, trailing_stop_pct),
+            MACrossStrategy(profit_threshold, trailing_stop_pct),
+        ]
+
+    def generate_signals(self, prices: List[float]) -> List[tuple[int, str, float]]:
+        """Aggregate signals from all sub-strategies."""
+        # Collect signals from each strategy as index -> (action, strength)
+        strategy_maps = []
+        for strat in self._strategies:
+            mapping = {i: (a, s) for i, a, s in strat.generate_signals(prices)}
+            strategy_maps.append(mapping)
+
+        signals: List[tuple[int, str, float]] = []
+        for i in range(len(prices)):
+            score = 0.0
+            for mapping in strategy_maps:
+                action_strength = mapping.get(i)
+                if action_strength is None:
+                    continue
+                action, strength = action_strength
+                if action == "BUY":
+                    score += strength
+                elif action == "SELL":
+                    score -= strength
+            if score >= 1.0:
+                strength = min(1.0, abs(score) / len(strategy_maps))
+                signals.append((i, "BUY", strength))
+            elif score <= -1.0:
+                strength = min(1.0, abs(score) / len(strategy_maps))
+                signals.append((i, "SELL", strength))
+        return signals


### PR DESCRIPTION
## Summary
- implement `CustomStrategy` as a hybrid strategy that aggregates RSI, MACD, Bollinger, and MA Cross signals
- export `CustomStrategy` in the strategies package and include it in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from services.data_service import DataService
from services.simulation import Simulation
from services.logger import Logger
from strategies import RSIStrategy, MACDStrategy, BollingerStrategy, MACrossStrategy, RandomStrategy, CustomStrategy

data_service = DataService()
logger = Logger()
strategies = [RSIStrategy(), MACDStrategy(), BollingerStrategy(), MACrossStrategy(), RandomStrategy(), CustomStrategy()]

sim = Simulation(data_service, logger, strategies)
results = sim.run()
print('Ran simulation with', len(results), 'strategies')
for r in results:
    print(r['name'], r['profit'])
PY

------
https://chatgpt.com/codex/tasks/task_e_6878d376508c832ebad2d84c635af84e