### PR TITLE
Fix hybrid strategy signal generation

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -8,6 +8,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Apply the five most commonly used and trusted trading strategies
 - Simulate long/short trades with an independent 10,000 TL balance for each strategy
 - Real-time buy/sell simulation adjusts position size according to signal strength
+- Optional "full balance" mode executes each trade with the entire balance for easier comparison
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
 - Separate graph for each strategy:
   - Price curve

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,6 +51,7 @@ Initially, the following example strategies will be used:
 - Bollinger Bands
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
+- Dynamic Hybrid (adaptive thresholding)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,6 +12,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Commission and slippage costs can be simulated for each trade
 - Adaptive position scaling reacts to winning streaks and market trend
 - Dynamic take-profit and trailing-stop levels adjust with volatility and signal strength
+- Adaptive opportunity trigger lowers the threshold after missed moves
 - EMA cross and volume breakout detection trigger initial trades with a small
   position which can pyramid as the trend confirms
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
@@ -59,6 +60,7 @@ Initially, the following example strategies will be used:
 - Custom (User defined or added later)
 - Dynamic Hybrid (ATR & volume filters, adaptive risk management, session-aware
  thresholds, market regime detection, multi-timeframe trend filters, commission/slippage simulation and parameter optimization)
+  with missed-opportunity detection and adaptive thresholding
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan
@@ -73,3 +75,15 @@ Please open a pull request or contact us if you would like to contribute or make
 This project is licensed under the MIT License.
 
 For the Turkish version of this document, see [readme.md](readme.md).
+
+### Example Parameter Tuning
+```python
+from strategies.dynamic_hybrid import DynamicHybridStrategy
+from services.data_service import DataService
+
+prices = DataService().get_historical_prices(limit=500)
+strategy = DynamicHybridStrategy()
+grid = {"base_threshold": [0.1, 0.15], "lookback": [40, 60]}
+best = strategy.optimize_by_regime(prices, grid)
+print(best)
+```

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,6 +14,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Dynamic take-profit and trailing-stop levels adjust with volatility and signal strength
 - Adaptive opportunity trigger lowers the threshold after missed moves
 - Missed opportunities are marked on charts and summarized with potential profit
+- Profit table compares realized profit with expected profit if missed trades were taken
 - EMA cross and volume breakout detection trigger initial trades with a small
   position which can pyramid as the trend confirms
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%

--- a/README_EN.md
+++ b/README_EN.md
@@ -62,7 +62,7 @@ Initially, the following example strategies will be used:
 - Custom (User defined or added later)
 - Dynamic Hybrid (ATR & volume filters, adaptive risk management, session-aware
  thresholds, market regime detection, multi-timeframe trend filters, commission/slippage simulation and parameter optimization)
-  with missed-opportunity detection and adaptive thresholding
+  with missed-opportunity detection, automatic trading of missed signals, adaptive thresholding, and an expected-profit table
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,7 +51,7 @@ Initially, the following example strategies will be used:
 - Bollinger Bands
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
-- Dynamic Hybrid (adaptive thresholding with win-rate weighting and regime detection)
+- Dynamic Hybrid (ATR/volume filtering, adaptive risk and regime-aware thresholds)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,7 +58,7 @@ Initially, the following example strategies will be used:
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
 - Dynamic Hybrid (ATR & volume filters, adaptive risk management, session-aware
-  thresholds, market regime detection and multi-timeframe trend filters)
+ thresholds, market regime detection, multi-timeframe trend filters, commission/slippage simulation and parameter optimization)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,7 +58,7 @@ Initially, the following example strategies will be used:
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
 - Dynamic Hybrid (ATR & volume filters, adaptive risk management, session-aware
-  thresholds and detailed decision logging)
+  thresholds, market regime detection and multi-timeframe trend filters)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,7 +51,8 @@ Initially, the following example strategies will be used:
 - Bollinger Bands
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
-- Dynamic Hybrid (ATR/volume filtering, adaptive risk and regime-aware thresholds)
+- Dynamic Hybrid (ATR & volume filters, adaptive risk management, session-aware
+  thresholds and detailed decision logging)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,6 +9,8 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Simulate long/short trades with an independent 10,000 TL balance for each strategy
 - Real-time buy/sell simulation adjusts position size according to signal strength
 - Optional "full balance" mode executes each trade with the entire balance for easier comparison
+- Commission and slippage costs can be simulated for each trade
+- Adaptive position scaling reacts to winning streaks and market trend
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
 - Separate graph for each strategy:
   - Price curve

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,6 +13,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Adaptive position scaling reacts to winning streaks and market trend
 - Dynamic take-profit and trailing-stop levels adjust with volatility and signal strength
 - Adaptive opportunity trigger lowers the threshold after missed moves
+- Missed opportunities are marked on charts and summarized with potential profit
 - EMA cross and volume breakout detection trigger initial trades with a small
   position which can pyramid as the trend confirms
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,7 +51,7 @@ Initially, the following example strategies will be used:
 - Bollinger Bands
 - MA Cross (Moving Average Cross)
 - Custom (User defined or added later)
-- Dynamic Hybrid (adaptive thresholding)
+- Dynamic Hybrid (adaptive thresholding with win-rate weighting and regime detection)
 Each strategy triggers trades according to its own rules and visualizes the results.
 
 ## Development Plan

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,6 +11,7 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Optional "full balance" mode executes each trade with the entire balance for easier comparison
 - Commission and slippage costs can be simulated for each trade
 - Adaptive position scaling reacts to winning streaks and market trend
+- Dynamic take-profit and trailing-stop levels adjust with volatility and signal strength
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
 - Separate graph for each strategy:
   - Price curve

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,6 +12,8 @@ This application aims to regularly fetch the Bitcoin price using the Binance API
 - Commission and slippage costs can be simulated for each trade
 - Adaptive position scaling reacts to winning streaks and market trend
 - Dynamic take-profit and trailing-stop levels adjust with volatility and signal strength
+- EMA cross and volume breakout detection trigger initial trades with a small
+  position which can pyramid as the trend confirms
 - Sells may override the signal strength and liquidate the entire position when the expected profit exceeds 2%
 - Separate graph for each strategy:
   - Price curve

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from strategies import (
     MACrossStrategy,
     RandomStrategy,
     CustomStrategy,
+    DynamicHybridStrategy,
 )
 
 
@@ -25,6 +26,7 @@ def main() -> None:
         MACrossStrategy(),
         RandomStrategy(),
         CustomStrategy(),
+        DynamicHybridStrategy(),
     ]
     # Request the maximum available candle history so the GUI can display
     # all available bars without limitation.

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def main() -> None:
         logger,
         strategies,
         price_limit=None,
-        full_balance=False,
+        full_balance=True,
         commission_pct=0.001,
         slippage_pct=0.0005,
         min_trade_size=0.0001,

--- a/main.py
+++ b/main.py
@@ -30,7 +30,13 @@ def main() -> None:
     ]
     # Request the maximum available candle history so the GUI can display
     # all available bars without limitation.
-    simulation = Simulation(data_service, logger, strategies, price_limit=None)
+    simulation = Simulation(
+        data_service,
+        logger,
+        strategies,
+        price_limit=None,
+        full_balance=False,
+    )
 
     logger.log("Application started")
     results = simulation.run()

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ def main() -> None:
         full_balance=False,
         commission_pct=0.001,
         slippage_pct=0.0005,
+        min_trade_size=0.0001,
     )
 
     logger.log("Application started")

--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ def main() -> None:
         strategies,
         price_limit=None,
         full_balance=False,
+        commission_pct=0.001,
+        slippage_pct=0.0005,
     )
 
     logger.log("Application started")

--- a/main.py
+++ b/main.py
@@ -26,7 +26,9 @@ def main() -> None:
         RandomStrategy(),
         CustomStrategy(),
     ]
-    simulation = Simulation(data_service, logger, strategies)
+    # Request the maximum available candle history so the GUI can display
+    # all available bars without limitation.
+    simulation = Simulation(data_service, logger, strategies, price_limit=None)
 
     logger.log("Application started")
     results = simulation.run()

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyükl�
 - EMA kesişimi ve hacim kırılımı ilk küçük pozisyonu tetikler, trend
   onaylandıkça kademeli alım yapılır
 - Kaçan fırsatları yakalamak için eşik otomatik düşürülür
+- Kâr tablosu gerçekleşen kazanç ile kaçan fırsatlardan doğabilecek maksimum kârı karşılaştırır
 
 Her strateji için ayrı grafik:
 

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ MA Cross (Moving Average Cross)
 
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
-Dynamic Hybrid (Uyarlanabilir eşiklerle)
+Dynamic Hybrid (Kazanma oranı ağırlıklı ve piyasa rejimine duyarlı)
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ Her strateji için 10.000 TL'lik bağımsız sanal bakiye ile long/short işleml
 Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyüklüğü ayarlanır
 - İsteğe bağlı "tüm bakiye" modu her al-sat sinyalinde mevcut bakiyenin tamamını kullanır
 - Beklenen kâr %2'yi aşıyorsa sinyal gücü düşük olsa bile tüm pozisyon satılabilir
+- Her işlemde komisyon ve slipaj maliyeti simüle edilebilir
+- Kazanan işlemler arttıkça pozisyon büyüklüğü otomatik olarak artar
 
 Her strateji için ayrı grafik:
 

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ MA Cross (Moving Average Cross)
 
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
-Dynamic Hybrid (Kazanma oranı ağırlıklı ve piyasa rejimine duyarlı)
+Dynamic Hybrid (ATR/hacim filtresi ve uyarlanabilir risk yönetimi)
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
 eşikleri, piyasa rejimi algısı, çoklu zaman dilimi trend filtreleri, komisyon/slipaj simülasyonu ve parametre optimizasyonu)
 kaçan fırsatları tespit ederek eşiği dinamik düşürür
+Grafikte kaçan fırsatlar özel işaretlerle gösterilir ve potansiyel kar raporlanır
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,8 @@ MA Cross (Moving Average Cross)
 
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
+Dynamic Hybrid (Uyarlanabilir eşiklerle)
+
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 
 Geliştirme Planı

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyükl�
 - Her işlemde komisyon ve slipaj maliyeti simüle edilebilir
 - Kazanan işlemler arttıkça pozisyon büyüklüğü otomatik olarak artar
 - Volatilite ve sinyal gücüne göre dinamik kar al ve trailing-stop seviyeleri
+- EMA kesişimi ve hacim kırılımı ilk küçük pozisyonu tetikler, trend
+  onaylandıkça kademeli alım yapılır
 
 Her strateji için ayrı grafik:
 

--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,8 @@ Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
 Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
 eşikleri, piyasa rejimi algısı, çoklu zaman dilimi trend filtreleri, komisyon/slipaj simülasyonu ve parametre optimizasyonu)
-kaçan fırsatları tespit ederek eşiği dinamik düşürür
-Grafikte kaçan fırsatlar özel işaretlerle gösterilir ve potansiyel kar raporlanır
+kaçan fırsatları tespit ederek otomatik alım/satım yapar, eşiği dinamik düşürür
+Grafikte kaçan fırsatlar özel işaretlerle gösterilir, potansiyel ve beklenen kar ayrı tabloda listelenir
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyükl�
 - Beklenen kâr %2'yi aşıyorsa sinyal gücü düşük olsa bile tüm pozisyon satılabilir
 - Her işlemde komisyon ve slipaj maliyeti simüle edilebilir
 - Kazanan işlemler arttıkça pozisyon büyüklüğü otomatik olarak artar
+- Volatilite ve sinyal gücüne göre dinamik kar al ve trailing-stop seviyeleri
 
 Her strateji için ayrı grafik:
 

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ MA Cross (Moving Average Cross)
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
 Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
-eşikleri ve ayrıntılı karar logları)
+eşikleri, piyasa rejimi algısı ve çoklu zaman dilimi trend filtreleri)
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyükl�
 - Volatilite ve sinyal gücüne göre dinamik kar al ve trailing-stop seviyeleri
 - EMA kesişimi ve hacim kırılımı ilk küçük pozisyonu tetikler, trend
   onaylandıkça kademeli alım yapılır
+- Kaçan fırsatları yakalamak için eşik otomatik düşürülür
 
 Her strateji için ayrı grafik:
 
@@ -83,6 +84,7 @@ Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
 Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
 eşikleri, piyasa rejimi algısı, çoklu zaman dilimi trend filtreleri, komisyon/slipaj simülasyonu ve parametre optimizasyonu)
+kaçan fırsatları tespit ederek eşiği dinamik düşürür
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 
@@ -99,3 +101,15 @@ Geliştirmeye katkı sağlamak veya öneride bulunmak için lütfen pull request
 Lisans
 Bu proje MIT Lisansı ile lisanslanmıştır.
 Bu belgenin Ingilizce versiyonu için [README_EN.md](README_EN.md) dosyasına bakabilirsiniz.
+
+### Parametre Ayarlama Örneği
+```python
+from strategies.dynamic_hybrid import DynamicHybridStrategy
+from services.data_service import DataService
+
+prices = DataService().get_historical_prices(limit=500)
+strategy = DynamicHybridStrategy()
+grid = {"base_threshold": [0.1, 0.15], "lookback": [40, 60]}
+best = strategy.optimize_by_regime(prices, grid)
+print(best)
+```

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Kısa sürede en çok kullanılan ve güvenli 5 farklı trade stratejisinin uygu
 
 Her strateji için 10.000 TL'lik bağımsız sanal bakiye ile long/short işlemlerini simüle etme
 Gerçek zamanlı al-sat simülasyonunda sinyal gücüne göre pozisyon büyüklüğü ayarlanır
+- İsteğe bağlı "tüm bakiye" modu her al-sat sinyalinde mevcut bakiyenin tamamını kullanır
 - Beklenen kâr %2'yi aşıyorsa sinyal gücü düşük olsa bile tüm pozisyon satılabilir
 
 Her strateji için ayrı grafik:

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,8 @@ MA Cross (Moving Average Cross)
 
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
-Dynamic Hybrid (ATR/hacim filtresi ve uyarlanabilir risk yönetimi)
+Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
+eşikleri ve ayrıntılı karar logları)
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ MA Cross (Moving Average Cross)
 Custom (Kullanıcıya özgü veya sonradan eklenebilir strateji)
 
 Dynamic Hybrid (ATR & hacim filtresi, uyarlanabilir risk yönetimi, seans
-eşikleri, piyasa rejimi algısı ve çoklu zaman dilimi trend filtreleri)
+eşikleri, piyasa rejimi algısı, çoklu zaman dilimi trend filtreleri, komisyon/slipaj simülasyonu ve parametre optimizasyonu)
 
 Her stratejinin kendi kuralları ile işlemleri tetiklenir ve sonuçlar görselleştirilir.
 

--- a/services/gui.py
+++ b/services/gui.py
@@ -80,21 +80,25 @@ class TradingApp:
         tree.heading("profit_threshold", text="Profit Th")
         tree.heading("trailing_stop", text="Trailing %")
         tree.pack(fill="both", expand=True)
+        def fmt(value: float | None, fmt_str: str = ".2f") -> str:
+            """Return formatted float or '-' when value is ``None``."""
+            return f"{value:{fmt_str}}" if value is not None else "-"
+
         for result in self.results:
             tree.insert(
                 "",
                 tk.END,
                 values=(
                     result["name"],
-                    f"{result['profit']:.2f}",
-                    f"{result['profit_pct']:.2f}",
-                    f"{result['final_balance']:.2f}",
-                    f"{result['bought']:.4f}",
-                    f"{result['sold']:.4f}",
-                    f"{result['remaining_btc']:.4f}",
-                    f"{result['holding_value']:.2f}",
-                    f"{result['profit_threshold']:.2f}",
-                    f"{result['trailing_stop_pct']:.2f}",
+                    fmt(result.get("profit")),
+                    fmt(result.get("profit_pct")),
+                    fmt(result.get("final_balance")),
+                    fmt(result.get("bought"), ".4f"),
+                    fmt(result.get("sold"), ".4f"),
+                    fmt(result.get("remaining_btc"), ".4f"),
+                    fmt(result.get("holding_value")),
+                    fmt(result.get("profit_threshold")),
+                    fmt(result.get("trailing_stop_pct")),
                 ),
             )
 

--- a/services/gui.py
+++ b/services/gui.py
@@ -87,6 +87,10 @@ class TradingApp:
             "missed_buy",
             "missed_sell",
             "missed_profit",
+            "expected_profit",
+            "trades",
+            "avg_trade",
+            "missed_count",
         )
         tree = ttk.Treeview(win, columns=cols, show="headings")
         tree.heading("strategy", text="Strategy")
@@ -102,6 +106,10 @@ class TradingApp:
         tree.heading("missed_buy", text="Missed Buy")
         tree.heading("missed_sell", text="Missed Sell")
         tree.heading("missed_profit", text="Missed Pot")
+        tree.heading("expected_profit", text="Expected")
+        tree.heading("trades", text="Trades")
+        tree.heading("avg_trade", text="Avg Size")
+        tree.heading("missed_count", text="Missed Cnt")
         tree.pack(fill="both", expand=True)
 
         for result in self.results:
@@ -122,6 +130,10 @@ class TradingApp:
                     result.get("missed_buy", 0),
                     result.get("missed_sell", 0),
                     fmt(result.get("missed_profit")),
+                    fmt(result.get("expected_profit")),
+                    result.get("trade_count", 0),
+                    fmt(result.get("avg_trade_size"), ".4f"),
+                    result.get("missed_count", 0),
                 ),
             )
 
@@ -137,6 +149,7 @@ class TradingApp:
             "balance",
             "reason",
             "pnl",
+            "potential",
         )
         frame = ttk.Frame(win)
         frame.pack(fill="both", expand=True)
@@ -158,6 +171,7 @@ class TradingApp:
                 "Balance (TL)",
                 "Reason",
                 "PnL",
+                "Potential",
             ],
         ):
             tree.heading(col, text=text)
@@ -178,6 +192,24 @@ class TradingApp:
                         fmt(log.get("balance_after")),
                         log.get("reason", ""),
                         fmt(log.get("pnl")),
+                        "",
+                    ),
+                )
+
+            for idx, price, action, pot in result.get("opportunities", []):
+                tree.insert(
+                    "",
+                    tk.END,
+                    values=(
+                        result["name"],
+                        idx,
+                        f"MISSED_{action}",
+                        "",
+                        fmt(price),
+                        "",
+                        "missed",
+                        "",
+                        fmt(pot),
                     ),
                 )
 

--- a/services/gui.py
+++ b/services/gui.py
@@ -43,8 +43,26 @@ class TradingApp:
                 for i, a, amt, price, _ in result["trades"]
                 if a == "SELL"
             ]
+            opps = result.get("opportunities", [])
             ax.scatter([b[0] for b in buys], [b[2] for b in buys], color="red", label="Buy")
             ax.scatter([s[0] for s in sells], [s[2] for s in sells], color="green", label="Sell")
+            if opps:
+                ax.scatter(
+                    [o[0] for o in opps],
+                    [o[1] for o in opps],
+                    color="purple",
+                    marker="x",
+                    label="Missed",
+                )
+                for idx, price in opps:
+                    ax.annotate(
+                        "X",
+                        (idx, price),
+                        textcoords="offset points",
+                        xytext=(0, -10),
+                        ha="center",
+                        color="purple",
+                    )
             for idx, amt, trade_price in buys:
                 ax.annotate(f"{amt:.4f}", (idx, trade_price), textcoords="offset points", xytext=(0, 5), ha="center", color="red")
             for idx, amt, trade_price in sells:

--- a/services/gui.py
+++ b/services/gui.py
@@ -140,7 +140,8 @@ class TradingApp:
                     ),
                 )
 
-        opt.configure(command=lambda *_: update_table())
+        # update table when filter option changes
+        filter_var.trace_add("write", lambda *_: update_table())
         update_table()
         tree.heading("strategy", text="Strategy")
         tree.heading("profit", text="Profit (TL)")
@@ -258,7 +259,8 @@ class TradingApp:
                         ),
                     )
 
-        opt.configure(command=lambda *_: update_trades())
+        # refresh trade log when filter option changes
+        filter_var.trace_add("write", lambda *_: update_trades())
         update_trades()
 
     def run(self) -> None:

--- a/services/gui.py
+++ b/services/gui.py
@@ -10,6 +10,11 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import matplotlib.pyplot as plt
 
 
+def fmt(value: float | None, fmt_str: str = ".2f") -> str:
+    """Return formatted float or '-' when value is ``None``."""
+    return f"{value:{fmt_str}}" if value is not None else "-"
+
+
 class TradingApp:
     """Display strategy price charts and profits."""
 
@@ -80,9 +85,6 @@ class TradingApp:
         tree.heading("profit_threshold", text="Profit Th")
         tree.heading("trailing_stop", text="Trailing %")
         tree.pack(fill="both", expand=True)
-        def fmt(value: float | None, fmt_str: str = ".2f") -> str:
-            """Return formatted float or '-' when value is ``None``."""
-            return f"{value:{fmt_str}}" if value is not None else "-"
 
         for result in self.results:
             tree.insert(
@@ -122,9 +124,9 @@ class TradingApp:
                         result["name"],
                         idx,
                         action,
-                        f"{amount:.4f}",
-                        f"{price:.2f}",
-                        f"{balance:.2f}",
+                        fmt(amount, ".4f"),
+                        fmt(price),
+                        fmt(balance),
                     ),
                 )
 

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -52,6 +52,7 @@ class Simulation:
             strategy_profit_threshold = getattr(
                 strategy, "profit_threshold", self.profit_threshold
             )
+            opps = getattr(strategy, "missed_opportunities", [])
             strategy_commission_pct = getattr(
                 strategy, "commission_pct", self.commission_pct
             )
@@ -215,11 +216,12 @@ class Simulation:
                     "bought": bought_total,
                     "sold": sold_total,
                     "remaining_btc": position,
-                    "holding_value": holding_value,
-                    "trailing_stops": trailing_closed,
-                    "profit_threshold": strategy_profit_threshold,
-                    "trailing_stop_pct": strategy_trailing_stop,
-                }
+                "holding_value": holding_value,
+                "trailing_stops": trailing_closed,
+                "profit_threshold": strategy_profit_threshold,
+                "trailing_stop_pct": strategy_trailing_stop,
+                "opportunities": opps,
+            }
             )
             self.logger.log(f"{strategy.name} profit: {profit:.2f}")
 

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -74,6 +74,7 @@ class Simulation:
             trailing_closed = 0
 
             performance_logs: List[dict] = []
+            trade_amounts: List[float] = []
 
             for i, price in enumerate(prices):
                 if position > 0:
@@ -144,6 +145,7 @@ class Simulation:
                                 "ts_pct": strategy_trailing_stop,
                             }
                         )
+                        trade_amounts.append(amount)
                         bought_total += amount
                         if price > highest_price:
                             highest_price = price
@@ -194,6 +196,7 @@ class Simulation:
                                 "pnl": pnl,
                             }
                         )
+                        trade_amounts.append(amount)
                         sold_total += amount
                         if position == 0:
                             highest_price = 0.0
@@ -220,6 +223,7 @@ class Simulation:
                         "balance_after": balance,
                     }
                 )
+                trade_amounts.append(position)
                 sold_total += position
                 position = 0.0
                 position_cost = 0.0
@@ -244,6 +248,11 @@ class Simulation:
                 miss_profit = 0.0
                 miss_logs = []
 
+            trade_count = len(trade_amounts)
+            avg_trade_size = sum(trade_amounts) / trade_count if trade_count else 0.0
+            expected_profit = profit + miss_profit
+            miss_count = len(miss_logs)
+
             results.append(
                 {
                     "name": strategy.name,
@@ -264,6 +273,10 @@ class Simulation:
                     "missed_buy": miss_buy,
                     "missed_sell": miss_sell,
                     "missed_profit": miss_profit,
+                    "expected_profit": expected_profit,
+                    "trade_count": trade_count,
+                    "avg_trade_size": avg_trade_size,
+                    "missed_count": miss_count,
                 }
             )
             self.logger.log(f"{strategy.name} profit: {profit:.2f}")

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -37,6 +37,9 @@ class Simulation:
 
         results = []
         for strategy in self.strategies:
+            # Allow strategies to prepare using the full price history
+            if hasattr(strategy, "before_run"):
+                strategy.before_run(prices)
             strategy_trailing_stop = (
                 getattr(strategy, "trailing_stop_pct", None)
                 if getattr(strategy, "trailing_stop_pct", None) is not None

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -18,17 +18,22 @@ class Simulation:
         strategies: Iterable,
         trailing_stop_pct: float = 0.01,
         profit_threshold: float = 0.02,
+        price_limit: int | None = 288,
     ) -> None:
         self.data_service = data_service
         self.logger = logger
         self.strategies = list(strategies)
         self.trailing_stop_pct = trailing_stop_pct
         self.profit_threshold = profit_threshold
+        self.price_limit = price_limit
 
     def run(self) -> List[dict]:
         """Run the simulation and return results per strategy."""
-        # Fetch 24 hours of data using 5 minute candles (288 total)
-        prices = self.data_service.get_historical_prices(limit=288, interval="5m")
+        # Fetch historical prices. ``price_limit`` may be ``None`` to request
+        # the maximum number of candles from the data service.
+        prices = self.data_service.get_historical_prices(
+            limit=self.price_limit, interval="5m"
+        )
 
         results = []
         for strategy in self.strategies:

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -142,6 +142,7 @@ class Simulation:
                         elif (
                             strength < 0.5
                             and position_cost > 0
+                            and strategy_profit_threshold is not None
                             and potential_profit / position_cost >= strategy_profit_threshold
                         ):
                             amount = position

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -74,7 +74,12 @@ class Simulation:
                     strategy_trailing_stop = getattr(
                         strategy, "trailing_stop_pct", self.trailing_stop_pct
                     )
-                    if price <= highest_price * (1 - strategy_trailing_stop):
+                    # Skip trailing stop check when ``strategy_trailing_stop`` is
+                    # ``None`` as some strategies may disable it by default.
+                    if (
+                        strategy_trailing_stop is not None
+                        and price <= highest_price * (1 - strategy_trailing_stop)
+                    ):
                         balance += position * price
                         trades.append((i, "SELL", position, price, balance))
                         performance_logs.append(

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -6,6 +6,7 @@ from .bollinger import BollingerStrategy
 from .ma_cross import MACrossStrategy
 from .random_strategy import RandomStrategy
 from .custom_strategy import CustomStrategy
+from .dynamic_hybrid import DynamicHybridStrategy
 
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "MACrossStrategy",
     "RandomStrategy",
     "CustomStrategy",
+    "DynamicHybridStrategy",
 ]

--- a/strategies/custom_strategy.py
+++ b/strategies/custom_strategy.py
@@ -11,7 +11,12 @@ from .rsi import RSIStrategy
 
 
 class CustomStrategy:
-    """Generate signals based on a consensus of other strategies."""
+    """Generate signals based on a consensus of other strategies.
+
+    The ``threshold`` value controls how strong the combined score must be
+    before emitting a signal.  A lower threshold results in more frequent
+    signals.
+    """
 
     name = "Hybrid"
 
@@ -19,9 +24,11 @@ class CustomStrategy:
         self,
         profit_threshold: float | None = None,
         trailing_stop_pct: float | None = None,
+        threshold: float = 0.5,
     ) -> None:
         self.profit_threshold = profit_threshold
         self.trailing_stop_pct = trailing_stop_pct
+        self.threshold = threshold
         self._strategies = [
             RSIStrategy(profit_threshold, trailing_stop_pct),
             MACDStrategy(profit_threshold, trailing_stop_pct),
@@ -49,10 +56,10 @@ class CustomStrategy:
                     score += strength
                 elif action == "SELL":
                     score -= strength
-            if score >= 1.0:
+            if score >= self.threshold:
                 strength = min(1.0, abs(score) / len(strategy_maps))
                 signals.append((i, "BUY", strength))
-            elif score <= -1.0:
+            elif score <= -self.threshold:
                 strength = min(1.0, abs(score) / len(strategy_maps))
                 signals.append((i, "SELL", strength))
         return signals

--- a/strategies/dynamic_hybrid.py
+++ b/strategies/dynamic_hybrid.py
@@ -78,7 +78,13 @@ class DynamicHybridStrategy:
         ema = pd.Series(prices).ewm(span=self.lookback).mean()
         window = prices[-self.lookback :]
         std = np.std(window)
-        slope = (ema.iloc[-1] - ema.iloc[-self.lookback]) / self.lookback
+        if len(ema) >= self.lookback:
+            start_idx = -self.lookback
+            length = self.lookback
+        else:
+            start_idx = 0
+            length = max(1, len(ema) - 1)
+        slope = (ema.iloc[-1] - ema.iloc[start_idx]) / length
         mean_price = np.mean(window)
         if std > self.std_coef * mean_price:
             self.market_regime = "volatile"

--- a/strategies/dynamic_hybrid.py
+++ b/strategies/dynamic_hybrid.py
@@ -1,0 +1,94 @@
+"""Dynamic hybrid trading strategy using multiple indicators."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing import Dict, List, Tuple
+
+
+class DynamicHybridStrategy:
+    """Generate signals with adaptive thresholds based on market regime."""
+
+    name = "Dynamic Hybrid"
+
+    def __init__(
+        self,
+        base_threshold: float = 0.18,
+        volatile_threshold: float = 0.25,
+        sideways_threshold: float = 0.11,
+        lookback: int = 50,
+    ) -> None:
+        self.indicator_winrates = {
+            "RSI": 0.5,
+            "MACD": 0.5,
+            "Bollinger": 0.5,
+            "MA Cross": 0.5,
+        }
+        self.market_regime = "trend"
+        self.base_threshold = base_threshold
+        self.volatile_threshold = volatile_threshold
+        self.sideways_threshold = sideways_threshold
+        self.lookback = lookback
+
+    def update_winrates(self, trade_logs: List[Dict]) -> None:
+        """Update indicator win rates using the last 20 trades."""
+        for ind in self.indicator_winrates:
+            trades = [t for t in trade_logs if t["indicator"] == ind][-20:]
+            if trades:
+                win = sum(1 for t in trades if t["pnl"] > 0)
+                self.indicator_winrates[ind] = win / len(trades)
+            else:
+                self.indicator_winrates[ind] = 0.5
+
+    def detect_market_regime(self, prices: List[float]) -> None:
+        """Classify market regime as trend, volatile or sideways."""
+        ema = pd.Series(prices).ewm(span=self.lookback).mean()
+        std = np.std(prices[-self.lookback :])
+        slope = (ema.iloc[-1] - ema.iloc[-self.lookback]) / self.lookback
+        mean_price = np.mean(prices[-self.lookback :])
+        if std > 0.004 * mean_price:
+            self.market_regime = "volatile"
+        elif abs(slope) < 0.0002:
+            self.market_regime = "sideways"
+        else:
+            self.market_regime = "trend"
+
+    def dynamic_voting(self, indicator_signals: Dict[str, Tuple[str, float]]) -> float:
+        """Vote on the final score using indicator win rates."""
+        score = 0.0
+        total_weight = sum(self.indicator_winrates.values())
+        for ind, (action, strength) in indicator_signals.items():
+            weight = (
+                self.indicator_winrates[ind] / total_weight if total_weight else 0.25
+            )
+            if action == "BUY":
+                score += strength * weight
+            elif action == "SELL":
+                score -= strength * weight
+        return score
+
+    def get_threshold(self) -> float:
+        """Return the buy/sell threshold for the current market regime."""
+        if self.market_regime == "trend":
+            return self.base_threshold
+        if self.market_regime == "volatile":
+            return self.volatile_threshold
+        return self.sideways_threshold
+
+    def generate_signal(
+        self,
+        prices: List[float],
+        indicator_signals: Dict[str, Tuple[str, float]],
+        trade_logs: List[Dict],
+    ) -> Tuple[str | None, float]:
+        """Return a single action and its score."""
+        self.update_winrates(trade_logs)
+        self.detect_market_regime(prices)
+        threshold = self.get_threshold()
+        score = self.dynamic_voting(indicator_signals)
+        if score >= threshold:
+            return "BUY", score
+        if score <= -threshold:
+            return "SELL", abs(score)
+        return None, 0.0

--- a/strategies/dynamic_hybrid.py
+++ b/strategies/dynamic_hybrid.py
@@ -6,6 +6,8 @@ each indicator. It also factors in the current price location within a
 lookback window and the short-term trend direction. Trade size scales
 dynamically with recent wins and trend strength, and optional
 correlation analysis can reduce risk when assets move together.
+Missed opportunities are recorded with estimated potential profit so
+that reports can compare realized versus expected gains.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- allow setting a threshold for consensus in `CustomStrategy`
- use the threshold when aggregating sub-strategy scores

## Testing
- `python -m py_compile strategies/custom_strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_6878d59bdc8c832e977806955a4a57f7